### PR TITLE
Fix concurrent request conflicts and add security hardening

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,13 @@
+name: Docker Build
+
+on:
+  pull_request:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t gotail:test .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@latest
+
+      - name: Generate templ files
+        run: templ generate
+
+      - name: Run tests
+        run: go test ./... -race

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Install templ and goose CLI
 RUN apk add --no-cache git
 RUN go install github.com/a-h/templ/cmd/templ@latest
-RUN go install github.com/pressly/goose/v3/cmd/goose@latest
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.24.1
 
 # Cache and build
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -205,6 +205,26 @@ docker run -p 8080:8080 -v $(pwd)/data:/app gotail
 
 ---
 
+## 🧪 Testing
+
+Run the full test suite with race detection:
+
+```bash
+go test ./... -race
+```
+
+The test suite includes:
+
+- **Store-level tests** (`db/sqlite/store_test.go`) — CRUD operations, attribute keys, services, monthly stats
+- **Concurrency tests** — concurrent writes, concurrent reads, and mixed read/write scenarios to verify WAL mode and connection pool safety
+- **Integration tests** (`handlers/integration_test.go`) — HTTP endpoint tests for POST /log (valid, invalid JSON, body too large, too many attributes), GET /api/logs, GET /api/stats, GET /api/attributes, GET /api/services
+- **Concurrent HTTP tests** — 25 parallel writes + 25 parallel reads to verify no deadlocks or transaction conflicts
+- **Middleware tests** (`middleware/`, `handlers/api/`) — API key auth, basic auth, EitherAuth, response format
+
+Each test creates a temporary SQLite database via `t.TempDir()`, applies migrations, and cleans up automatically.
+
+---
+
 ## 🛠 Development
 
 Development is powered by [`air`](https://github.com/air-verse/air). To start developing:

--- a/db/sqlite/get.go
+++ b/db/sqlite/get.go
@@ -1,6 +1,8 @@
 package sqlite
 
 import (
+	"context"
+	"database/sql"
 	"gotail/models"
 	"strings"
 	"time"
@@ -16,6 +18,12 @@ func (s *SQLiteStore) GetLogsFiltered(
 ) ([]models.LogEntry, int, error) {
 	offset := (page - 1) * limit
 
+	tx, err := s.readDB.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback()
+
 	var (
 		whereClauses []string
 		args         []interface{}
@@ -25,7 +33,6 @@ func (s *SQLiteStore) GetLogsFiltered(
 		SELECT l.*
 		FROM log l`
 
-	// Add join if filtering on attribute
 	if attrKey != "" && attrValue != "" {
 		query += `
 			INNER JOIN attribute a ON a.log_id = l.id`
@@ -63,16 +70,21 @@ func (s *SQLiteStore) GetLogsFiltered(
 	}
 
 	var count int
-	countArgs := args[:len(args)-2] // exclude limit and offset
-	if err := s.db.QueryRow(countQuery, countArgs...).Scan(&count); err != nil {
+	countArgs := args[:len(args)-2]
+	if err := tx.QueryRow(countQuery, countArgs...).Scan(&count); err != nil {
 		return nil, 0, err
 	}
 
-	rows, err := s.db.Query(query, args...)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer rows.Close()
+
+	loc, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		loc = time.FixedZone("CET", 1*60*60)
+	}
 
 	var logs []models.LogEntry
 	for rows.Next() {
@@ -95,15 +107,10 @@ func (s *SQLiteStore) GetLogsFiltered(
 		if err != nil {
 			return nil, 0, err
 		}
-		loc, err := time.LoadLocation("Europe/Oslo")
-		if err != nil {
-			// fallback
-			loc = time.FixedZone("CET", 1*60*60) // backup zone
-		}
 
 		entry.Timestamp = entry.Timestamp.In(loc)
 
-		attrRows, err := s.db.Query(`SELECT key, value FROM attribute WHERE log_id = ?`, entry.ID)
+		attrRows, err := tx.Query(`SELECT key, value FROM attribute WHERE log_id = ?`, entry.ID)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -130,32 +137,30 @@ func (s *SQLiteStore) GetLogsFiltered(
 	return logs, count, nil
 }
 
-
 func (s *SQLiteStore) GetAttributeKeys() ([]string, error) {
-    // Example implementation, adjust according to your schema
-    rows, err := s.db.Query("SELECT DISTINCT key FROM attribute")
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := s.readDB.Query("SELECT DISTINCT key FROM attribute")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var keys []string
-    for rows.Next() {
-        var key string
-        if err := rows.Scan(&key); err != nil {
-            return nil, err
-        }
-        keys = append(keys, key)
-    }
-    if err := rows.Err(); err != nil {
-        return nil, err
-    }
-    return keys, nil
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 func (s *SQLiteStore) GetTotalLogs() (int, error) {
 	var count int
-	err := s.db.QueryRow("SELECT COUNT(*) FROM log").Scan(&count)
+	err := s.readDB.QueryRow("SELECT COUNT(*) FROM log").Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -163,7 +168,7 @@ func (s *SQLiteStore) GetTotalLogs() (int, error) {
 }
 
 func (s *SQLiteStore) GetServices() ([]string, error) {
-	rows, err := s.db.Query("SELECT DISTINCT service_name FROM log")
+	rows, err := s.readDB.Query("SELECT DISTINCT service_name FROM log")
 	if err != nil {
 		return nil, err
 	}

--- a/db/sqlite/insert.go
+++ b/db/sqlite/insert.go
@@ -7,10 +7,10 @@ import (
 )
 
 func (s *SQLiteStore) InsertLog(entry models.LogEntry) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	tx, err := s.db.Begin()
+	tx, err := s.writeDB.Begin()
 	if err != nil {
 		return err
 	}

--- a/db/sqlite/stats.go
+++ b/db/sqlite/stats.go
@@ -51,7 +51,7 @@ func (s *SQLiteStore) CountLogsBySeverity(year int, month int) (map[string]int, 
 func (s *SQLiteStore) CountLogsPerDay(year int, month int) (map[int]int, error) {
 	start, end := dateRange(year, month)
 	rows, err := s.readDB.Query(`
-		SELECT CAST(strftime('%d', timestamp) AS INTEGER) AS day, COUNT(*)
+		SELECT CAST(substr(timestamp, 9, 2) AS INTEGER) AS day, COUNT(*)
 		FROM log
 		WHERE timestamp >= ? AND timestamp < ?
 		GROUP BY day

--- a/db/sqlite/stats.go
+++ b/db/sqlite/stats.go
@@ -1,121 +1,124 @@
 package sqlite
 
 import (
-	"fmt"
-	"strconv"
+	"time"
 )
 
+func dateRange(year int, month int) (string, string) {
+	loc, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		loc = time.FixedZone("CET", 1*60*60)
+	}
+	start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, loc)
+	end := start.AddDate(0, 1, 0)
+	return start.Format(time.RFC3339), end.Format(time.RFC3339)
+}
+
 func (s *SQLiteStore) CountLogsByMonth(year int, month int) (int, error) {
-	datePrefix := fmt.Sprintf("%04d-%02d", year, month)
+	start, end := dateRange(year, month)
 	var count int
-	err := s.db.QueryRow("SELECT COUNT(*) FROM log WHERE timestamp LIKE ?", datePrefix+"%").Scan(&count)
+	err := s.readDB.QueryRow(
+		"SELECT COUNT(*) FROM log WHERE timestamp >= ? AND timestamp < ?",
+		start, end,
+	).Scan(&count)
 	return count, err
 }
 
 func (s *SQLiteStore) CountLogsBySeverity(year int, month int) (map[string]int, error) {
-    datePrefix := fmt.Sprintf("%04d-%02d", year, month)
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT severity_text, COUNT(*)
+		FROM log
+		WHERE timestamp >= ? AND timestamp < ?
+		GROUP BY severity_text`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    rows, err := s.db.Query(`
-        SELECT severity_text, COUNT(*) 
-        FROM log 
-        WHERE timestamp LIKE ? 
-        GROUP BY severity_text`, datePrefix+"%")
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
-
-    result := make(map[string]int)
-    for rows.Next() {
-        var severity string
-        var count int
-        if err := rows.Scan(&severity, &count); err != nil {
-            return nil, err
-        }
-        result[severity] = count
-    }
-
-    return result, rows.Err()
+	result := make(map[string]int)
+	for rows.Next() {
+		var severity string
+		var count int
+		if err := rows.Scan(&severity, &count); err != nil {
+			return nil, err
+		}
+		result[severity] = count
+	}
+	return result, rows.Err()
 }
 
 func (s *SQLiteStore) CountLogsPerDay(year int, month int) (map[int]int, error) {
-    datePrefix := fmt.Sprintf("%04d-%02d", year, month)
-    rows, err := s.db.Query(`
-        SELECT substr(timestamp, 9, 2) AS day, COUNT(*) 
-        FROM log 
-        WHERE timestamp LIKE ? 
-        GROUP BY day 
-        ORDER BY day`, datePrefix+"%")
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT CAST(strftime('%d', timestamp) AS INTEGER) AS day, COUNT(*)
+		FROM log
+		WHERE timestamp >= ? AND timestamp < ?
+		GROUP BY day
+		ORDER BY day`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    result := make(map[int]int)
-    for rows.Next() {
-        var dayStr string
-        var count int
-        if err := rows.Scan(&dayStr, &count); err != nil {
-            return nil, err
-        }
-        day, _ := strconv.Atoi(dayStr)
-        result[day] = count
-    }
-
-    return result, rows.Err()
+	result := make(map[int]int)
+	for rows.Next() {
+		var day int
+		var count int
+		if err := rows.Scan(&day, &count); err != nil {
+			return nil, err
+		}
+		result[day] = count
+	}
+	return result, rows.Err()
 }
 
 func (s *SQLiteStore) CountLogsByService(year int, month int) (map[string]int, error) {
-    datePrefix := fmt.Sprintf("%04d-%02d", year, month)
-    rows, err := s.db.Query(`
-        SELECT service_name, COUNT(*) 
-        FROM log 
-        WHERE timestamp LIKE ? AND service_name IS NOT NULL 
-        GROUP BY service_name`, datePrefix+"%")
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT service_name, COUNT(*)
+		FROM log
+		WHERE timestamp >= ? AND timestamp < ? AND service_name IS NOT NULL
+		GROUP BY service_name`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    result := make(map[string]int)
-    for rows.Next() {
-        var service string
-        var count int
-        if err := rows.Scan(&service, &count); err != nil {
-            return nil, err
-        }
-        result[service] = count
-    }
-
-    return result, rows.Err()
+	result := make(map[string]int)
+	for rows.Next() {
+		var service string
+		var count int
+		if err := rows.Scan(&service, &count); err != nil {
+			return nil, err
+		}
+		result[service] = count
+	}
+	return result, rows.Err()
 }
 
 func (s *SQLiteStore) CountLogsByAttribute(year int, month int) (map[string]int, error) {
-    datePrefix := fmt.Sprintf("%04d-%02d", year, month)
-    query := `
-        SELECT key, COUNT(DISTINCT log_id) 
-        FROM attribute
-        WHERE log_id IN (
-            SELECT id FROM log WHERE timestamp LIKE ?
-        )
-        GROUP BY key;
-    `
-    rows, err := s.db.Query(query, datePrefix+"%")
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT key, COUNT(DISTINCT log_id)
+		FROM attribute
+		WHERE log_id IN (
+			SELECT id FROM log WHERE timestamp >= ? AND timestamp < ?
+		)
+		GROUP BY key`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    result := make(map[string]int)
-    for rows.Next() {
-        var key string
-        var count int
-        if err := rows.Scan(&key, &count); err != nil {
-            return nil, err
-        }
-        result[key] = count
-    }
-
-    return result, rows.Err()
+	result := make(map[string]int)
+	for rows.Next() {
+		var key string
+		var count int
+		if err := rows.Scan(&key, &count); err != nil {
+			return nil, err
+		}
+		result[key] = count
+	}
+	return result, rows.Err()
 }
-

--- a/db/sqlite/store.go
+++ b/db/sqlite/store.go
@@ -2,24 +2,69 @@ package sqlite
 
 import (
 	"database/sql"
+	"fmt"
 	"sync"
 
 	_ "modernc.org/sqlite"
 )
 
 type SQLiteStore struct {
-	db *sql.DB
-	mutex sync.Mutex
+	writeDB *sql.DB
+	readDB  *sql.DB
+	mu      sync.Mutex
 }
 
 func NewSQLiteStore(dsn string) (*SQLiteStore, error) {
-	db, err := sql.Open("sqlite", dsn)
+	writeDSN := dsn + "?_busy_timeout=5000"
+	readDSN := dsn + "?_busy_timeout=5000"
+
+	writeDB, err := sql.Open("sqlite", writeDSN)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open write db: %w", err)
 	}
-	return &SQLiteStore{db: db}, nil
+	writeDB.SetMaxOpenConns(1)
+
+	// Enable WAL mode
+	if _, err := writeDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("enable WAL: %w", err)
+	}
+	if _, err := writeDB.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("set synchronous: %w", err)
+	}
+	if _, err := writeDB.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("enable foreign keys: %w", err)
+	}
+
+	readDB, err := sql.Open("sqlite", readDSN)
+	if err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("open read db: %w", err)
+	}
+	readDB.SetMaxOpenConns(8)
+
+	// Make read connection read-only
+	if _, err := readDB.Exec("PRAGMA query_only=ON"); err != nil {
+		writeDB.Close()
+		readDB.Close()
+		return nil, fmt.Errorf("set query_only: %w", err)
+	}
+
+	return &SQLiteStore{writeDB: writeDB, readDB: readDB}, nil
 }
 
 func (s *SQLiteStore) Close() error {
-	return s.db.Close()
+	writeErr := s.writeDB.Close()
+	readErr := s.readDB.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return readErr
+}
+
+func (s *SQLiteStore) ExecRaw(sql string) error {
+	_, err := s.writeDB.Exec(sql)
+	return err
 }

--- a/db/sqlite/store_test.go
+++ b/db/sqlite/store_test.go
@@ -1,0 +1,197 @@
+package sqlite_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"gotail/models"
+)
+
+func makeLogEntry(id string, svc string) models.LogEntry {
+	s := svc
+	return models.LogEntry{
+		ID:             id,
+		Timestamp:      time.Now().UTC(),
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           "test log body",
+		ServiceName:    &s,
+		Attributes:     map[string]any{"env": "test"},
+	}
+}
+
+func TestInsertAndGetLogs(t *testing.T) {
+	store := newTestStore(t)
+
+	entry := makeLogEntry("test-1", "svc-a")
+	if err := store.InsertLog(entry); err != nil {
+		t.Fatalf("InsertLog failed: %v", err)
+	}
+
+	logs, count, err := store.GetLogsFiltered(1, 10, "", "", "", "")
+	if err != nil {
+		t.Fatalf("GetLogsFiltered failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected count 1, got %d", count)
+	}
+	if len(logs) != 1 {
+		t.Errorf("expected 1 log, got %d", len(logs))
+	}
+	if logs[0].ID != "test-1" {
+		t.Errorf("expected ID test-1, got %s", logs[0].ID)
+	}
+}
+
+func TestGetAttributeKeys(t *testing.T) {
+	store := newTestStore(t)
+
+	entry := makeLogEntry("test-1", "svc-a")
+	entry.Attributes = map[string]any{"env": "prod", "region": "eu"}
+	store.InsertLog(entry)
+
+	keys, err := store.GetAttributeKeys()
+	if err != nil {
+		t.Fatalf("GetAttributeKeys failed: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(keys))
+	}
+}
+
+func TestGetServices(t *testing.T) {
+	store := newTestStore(t)
+
+	store.InsertLog(makeLogEntry("test-1", "svc-a"))
+	store.InsertLog(makeLogEntry("test-2", "svc-b"))
+
+	services, err := store.GetServices()
+	if err != nil {
+		t.Fatalf("GetServices failed: %v", err)
+	}
+	if len(services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(services))
+	}
+}
+
+func TestCountLogsByMonth(t *testing.T) {
+	store := newTestStore(t)
+
+	now := time.Now().UTC()
+	entry := makeLogEntry("test-1", "svc-a")
+	entry.Timestamp = now
+	store.InsertLog(entry)
+
+	count, err := store.CountLogsByMonth(now.Year(), int(now.Month()))
+	if err != nil {
+		t.Fatalf("CountLogsByMonth failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+}
+
+func TestConcurrentWrites(t *testing.T) {
+	store := newTestStore(t)
+	var wg sync.WaitGroup
+	errs := make(chan error, 50)
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			entry := makeLogEntry(fmt.Sprintf("concurrent-%d", i), "svc-a")
+			if err := store.InsertLog(entry); err != nil {
+				errs <- fmt.Errorf("insert %d: %w", i, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+
+	total, err := store.GetTotalLogs()
+	if err != nil {
+		t.Fatalf("GetTotalLogs failed: %v", err)
+	}
+	if total != 50 {
+		t.Errorf("expected 50 logs, got %d", total)
+	}
+}
+
+func TestConcurrentReads(t *testing.T) {
+	store := newTestStore(t)
+
+	// Insert test data
+	for i := 0; i < 10; i++ {
+		store.InsertLog(makeLogEntry(fmt.Sprintf("read-%d", i), "svc-a"))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, count, err := store.GetLogsFiltered(1, 10, "", "", "", "")
+			if err != nil {
+				errs <- fmt.Errorf("GetLogsFiltered: %w", err)
+				return
+			}
+			if count != 10 {
+				errs <- fmt.Errorf("expected 10, got %d", count)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestConcurrentReadsAndWrites(t *testing.T) {
+	store := newTestStore(t)
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+
+	// 25 concurrent writers
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			entry := makeLogEntry(fmt.Sprintf("mixed-%d", i), "svc-a")
+			if err := store.InsertLog(entry); err != nil {
+				errs <- fmt.Errorf("insert %d: %w", i, err)
+			}
+		}(i)
+	}
+
+	// 25 concurrent readers
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := store.GetLogsFiltered(1, 10, "", "", "", "")
+			if err != nil {
+				errs <- fmt.Errorf("GetLogsFiltered: %w", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}

--- a/db/sqlite/testhelper_test.go
+++ b/db/sqlite/testhelper_test.go
@@ -1,0 +1,67 @@
+package sqlite_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotail/db/sqlite"
+)
+
+func newTestStore(t *testing.T) *sqlite.SQLiteStore {
+	t.Helper()
+	dir := t.TempDir()
+	dsn := filepath.Join(dir, "test.db")
+
+	store, err := sqlite.NewSQLiteStore(dsn)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	// Apply migration SQL directly
+	migrationSQL, err := os.ReadFile("../../migrations/20250625192434_log.sql")
+	if err != nil {
+		t.Fatalf("failed to read migration: %v", err)
+	}
+
+	// Extract only the Up migration (between +goose Up and +goose Down)
+	sql := extractUpMigration(string(migrationSQL))
+
+	if err := store.ExecRaw(sql); err != nil {
+		t.Fatalf("failed to apply migration: %v", err)
+	}
+
+	t.Cleanup(func() {
+		store.Close()
+	})
+
+	return store
+}
+
+func extractUpMigration(content string) string {
+	inUp := false
+	inStatement := false
+	var result string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "+goose Up") {
+			inUp = true
+			continue
+		}
+		if strings.Contains(line, "+goose Down") {
+			break
+		}
+		if inUp && strings.Contains(line, "+goose StatementBegin") {
+			inStatement = true
+			continue
+		}
+		if inUp && strings.Contains(line, "+goose StatementEnd") {
+			inStatement = false
+			continue
+		}
+		if inUp && inStatement {
+			result += line + "\n"
+		}
+	}
+	return result
+}

--- a/docs/superpowers/plans/2026-03-11-concurrency-fix-and-hardening.md
+++ b/docs/superpowers/plans/2026-03-11-concurrency-fix-and-hardening.md
@@ -1,0 +1,1377 @@
+# Concurrency Fix & Security Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix SQLite concurrent request conflicts and add security hardening (input validation, panic recovery, auth logging, stats date filtering).
+
+**Architecture:** Dual SQLite connection pools (read/write separation) with WAL mode. New middleware for body size limits and panic recovery. Field validation in insert handler. Proper date range queries in stats.
+
+**Tech Stack:** Go 1.23, modernc.org/sqlite, standard net/http, sync.Mutex
+
+**Spec:** `docs/superpowers/specs/2026-03-11-concurrency-fix-and-hardening-design.md`
+
+---
+
+## Chunk 1: SQLite Store Restructure
+
+### Task 1: Restructure SQLiteStore with dual connection pools
+
+**Files:**
+- Modify: `db/sqlite/store.go`
+- Modify: `main.go:42-46` (remove broken busy_timeout logic)
+
+- [ ] **Step 1: Update SQLiteStore struct and constructor**
+
+Replace `db/sqlite/store.go` entirely:
+
+```go
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+
+	_ "modernc.org/sqlite"
+)
+
+type SQLiteStore struct {
+	writeDB *sql.DB
+	readDB  *sql.DB
+	mu      sync.Mutex
+}
+
+func NewSQLiteStore(dsn string) (*SQLiteStore, error) {
+	writeDSN := dsn + "?_busy_timeout=5000"
+	readDSN := dsn + "?_busy_timeout=5000"
+
+	writeDB, err := sql.Open("sqlite", writeDSN)
+	if err != nil {
+		return nil, fmt.Errorf("open write db: %w", err)
+	}
+	writeDB.SetMaxOpenConns(1)
+
+	// Enable WAL mode
+	if _, err := writeDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("enable WAL: %w", err)
+	}
+	if _, err := writeDB.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("set synchronous: %w", err)
+	}
+	if _, err := writeDB.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("enable foreign keys: %w", err)
+	}
+
+	readDB, err := sql.Open("sqlite", readDSN)
+	if err != nil {
+		writeDB.Close()
+		return nil, fmt.Errorf("open read db: %w", err)
+	}
+	readDB.SetMaxOpenConns(8)
+
+	// Make read connection read-only
+	if _, err := readDB.Exec("PRAGMA query_only=ON"); err != nil {
+		writeDB.Close()
+		readDB.Close()
+		return nil, fmt.Errorf("set query_only: %w", err)
+	}
+
+	return &SQLiteStore{writeDB: writeDB, readDB: readDB}, nil
+}
+
+func (s *SQLiteStore) Close() error {
+	writeErr := s.writeDB.Close()
+	readErr := s.readDB.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return readErr
+}
+```
+
+- [ ] **Step 2: Remove broken busy_timeout logic from main.go**
+
+In `main.go`, remove lines 42-46:
+
+```go
+	// Set busy timeout for SQLite if using SQLite
+	// This is important to avoid database lock issues
+	if dsn == "sqlite" {
+		dsn = dsn + "?_busy_timeout=5000"
+	}
+```
+
+- [ ] **Step 3: Update InsertLog to use writeDB**
+
+In `db/sqlite/insert.go`, change line 13 from `s.db.Begin()` to `s.writeDB.Begin()`:
+
+```go
+func (s *SQLiteStore) InsertLog(entry models.LogEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.writeDB.Begin()
+```
+
+- [ ] **Step 4: Update GetLogsFiltered to use readDB with transaction**
+
+In `db/sqlite/get.go`, add `"context"` and `"database/sql"` to imports, then wrap the multi-query read in a read-only transaction. Replace the method body:
+
+```go
+func (s *SQLiteStore) GetLogsFiltered(
+	page int,
+	limit int,
+	severity string,
+	attrKey string,
+	attrValue string,
+	service string,
+) ([]models.LogEntry, int, error) {
+	offset := (page - 1) * limit
+
+	tx, err := s.readDB.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback()
+
+	var (
+		whereClauses []string
+		args         []interface{}
+	)
+
+	query := `
+		SELECT l.*
+		FROM log l`
+
+	if attrKey != "" && attrValue != "" {
+		query += `
+			INNER JOIN attribute a ON a.log_id = l.id`
+		whereClauses = append(whereClauses, "a.key = ? AND a.value LIKE ?")
+		args = append(args, attrKey, "%"+attrValue+"%")
+	}
+
+	if severity != "" {
+		whereClauses = append(whereClauses, "l.severity_text = ?")
+		args = append(args, severity)
+	}
+
+	if service != "" {
+		whereClauses = append(whereClauses, "l.service_name = ?")
+		args = append(args, service)
+	}
+
+	if len(whereClauses) > 0 {
+		query += " WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	query += " ORDER BY l.timestamp DESC LIMIT ? OFFSET ?"
+	args = append(args, limit, offset)
+
+	// Count query
+	countQuery := `
+		SELECT COUNT(DISTINCT l.id)
+		FROM log l`
+	if attrKey != "" && attrValue != "" {
+		countQuery += `
+			INNER JOIN attribute a ON a.log_id = l.id`
+	}
+	if len(whereClauses) > 0 {
+		countQuery += " WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	var count int
+	countArgs := args[:len(args)-2]
+	if err := tx.QueryRow(countQuery, countArgs...).Scan(&count); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	loc, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		loc = time.FixedZone("CET", 1*60*60)
+	}
+
+	var logs []models.LogEntry
+	for rows.Next() {
+		var entry models.LogEntry
+
+		err := rows.Scan(
+			&entry.ID,
+			&entry.Timestamp,
+			&entry.SeverityText,
+			&entry.SeverityNumber,
+			&entry.Body,
+			&entry.ServiceName,
+			&entry.ServiceVersion,
+			&entry.ServiceInstanceID,
+			&entry.HostName,
+			&entry.ScopeName,
+			&entry.ScopeVersion,
+			&entry.CreatedAt,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		entry.Timestamp = entry.Timestamp.In(loc)
+
+		attrRows, err := tx.Query(`SELECT key, value FROM attribute WHERE log_id = ?`, entry.ID)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		entry.Attributes = make(map[string]any)
+		for attrRows.Next() {
+			var k string
+			var v any
+			if err := attrRows.Scan(&k, &v); err != nil {
+				attrRows.Close()
+				return nil, 0, err
+			}
+			entry.Attributes[k] = v
+		}
+		attrRows.Close()
+
+		logs = append(logs, entry)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	return logs, count, nil
+}
+```
+
+- [ ] **Step 5: Update simple read methods to use readDB**
+
+In `db/sqlite/get.go`, update `GetAttributeKeys`, `GetTotalLogs`, `GetServices` — replace all `s.db.` with `s.readDB.` (no transaction needed for single queries).
+
+- [ ] **Step 6: Update stats methods to use readDB**
+
+In `db/sqlite/stats.go`, replace all `s.db.` with `s.readDB.` in all five methods.
+
+- [ ] **Step 7: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+Expected: no errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add db/sqlite/store.go db/sqlite/insert.go db/sqlite/get.go db/sqlite/stats.go main.go
+git commit -m "feat: WAL mode with dual read/write connection pools
+
+Fixes #9 - separates read and write SQLite connections to prevent
+transaction conflicts during concurrent requests."
+```
+
+---
+
+## Chunk 2: Input Validation
+
+### Task 2: Add MaxBodySize middleware
+
+**Files:**
+- Create: `middleware/max_body_size.go`
+
+- [ ] **Step 1: Create the middleware**
+
+```go
+package middleware
+
+import (
+	"net/http"
+)
+
+func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Apply middleware in main.go**
+
+In `main.go`, wrap the `/log` handler with `MaxBodySize(1 << 20)` (1MB). Replace the route registration for `/log`:
+
+Where the `/log` routes are registered (lines 79-84), wrap the handler:
+
+```go
+logHandlerWithLimit := middleware.MaxBodySize(1 << 20)(http.HandlerFunc(logHandler.HandleLogInsert))
+
+if user != "" && pass != "" {
+    http.Handle("/log", middleware.EitherAuth(user, pass)(logHandlerWithLimit))
+} else if apiKeys != "" {
+    http.Handle("/log", middleware.APIKeyAuth()(logHandlerWithLimit))
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+
+### Task 3: Add field validation to insert handler
+
+**Files:**
+- Modify: `handlers/logging/insert.go`
+
+- [ ] **Step 1: Add validation after JSON parsing**
+
+In `handlers/logging/insert.go`, add validation between the JSON unmarshal (line 34) and the ID assignment (line 36). Add a `validateLogEntry` function:
+
+```go
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"gotail/db"
+	"gotail/models"
+)
+
+const (
+	maxBodyLen     = 65536 // 64KB
+	maxStringLen   = 256
+	maxAttributes  = 50
+	maxAttrKeyLen  = 256
+	maxAttrValueLen = 4096 // 4KB
+)
+
+type LogHandler struct {
+	Store db.LogStore
+}
+
+func (h *LogHandler) HandleLogInsert(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Only POST supported", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSONError(w, "Request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	var logEntry models.LogEntry
+	if err := json.Unmarshal(body, &logEntry); err != nil {
+		writeJSONError(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if msg := validateLogEntry(logEntry); msg != "" {
+		writeJSONError(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	logEntry.ID = uuid.New().String()
+
+	if logEntry.Timestamp.IsZero() {
+		logEntry.Timestamp = time.Now().UTC()
+	}
+
+	err = h.Store.InsertLog(logEntry)
+	if err != nil {
+		log.Printf("Failed to insert log: %v", err)
+		writeJSONError(w, "Failed to insert log", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func validateLogEntry(e models.LogEntry) string {
+	if len(e.Body) > maxBodyLen {
+		return fmt.Sprintf("body exceeds maximum length of %d bytes", maxBodyLen)
+	}
+	if len(e.SeverityText) > maxStringLen {
+		return fmt.Sprintf("severity_text exceeds maximum length of %d chars", maxStringLen)
+	}
+	if e.ServiceName != nil && len(*e.ServiceName) > maxStringLen {
+		return fmt.Sprintf("service_name exceeds maximum length of %d chars", maxStringLen)
+	}
+	if e.HostName != nil && len(*e.HostName) > maxStringLen {
+		return fmt.Sprintf("host_name exceeds maximum length of %d chars", maxStringLen)
+	}
+	if e.ScopeName != nil && len(*e.ScopeName) > maxStringLen {
+		return fmt.Sprintf("scope_name exceeds maximum length of %d chars", maxStringLen)
+	}
+	if len(e.Attributes) > maxAttributes {
+		return fmt.Sprintf("attributes exceeds maximum count of %d", maxAttributes)
+	}
+	for k, v := range e.Attributes {
+		if len(k) > maxAttrKeyLen {
+			return fmt.Sprintf("attribute key %q exceeds maximum length of %d chars", k, maxAttrKeyLen)
+		}
+		if str, ok := v.(string); ok && len(str) > maxAttrValueLen {
+			return fmt.Sprintf("attribute value for key %q exceeds maximum length of %d bytes", k, maxAttrValueLen)
+		}
+	}
+	return ""
+}
+
+func writeJSONError(w http.ResponseWriter, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add middleware/max_body_size.go handlers/logging/insert.go main.go
+git commit -m "feat: add input validation and body size limits on POST /log"
+```
+
+---
+
+## Chunk 3: Panic Recovery & Auth Logging
+
+### Task 4: Add panic recovery middleware
+
+**Files:**
+- Create: `middleware/recovery.go`
+- Modify: `main.go`
+
+- [ ] **Step 1: Create recovery middleware**
+
+```go
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"runtime/debug"
+)
+
+func Recovery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("PANIC: %v\n%s", err, debug.Stack())
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error":"internal server error"}`))
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+- [ ] **Step 2: Apply recovery middleware in main.go**
+
+In `main.go`, wrap the default mux with recovery. Replace the final `http.ListenAndServe` line:
+
+```go
+log.Fatal(http.ListenAndServe(":8080", middleware.Recovery(http.DefaultServeMux)))
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add middleware/recovery.go main.go
+git commit -m "feat: add panic recovery middleware"
+```
+
+### Task 5: Add failed auth attempt logging
+
+**Files:**
+- Modify: `middleware/basic_auth.go`
+- Modify: `middleware/api_key_auth.go`
+
+- [ ] **Step 1: Add logging to BasicAuth**
+
+In `middleware/basic_auth.go`, add `"log"` to imports and log on failed auth. The two failure paths are: `!ok` (no credentials) and failed comparison. Update both to log before calling `unauthorized(w)`:
+
+```go
+package middleware
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"log"
+	"net/http"
+)
+
+func BasicAuth(expectedUser, expectedPass string) func(http.Handler) http.Handler {
+	userHash := sha256.Sum256([]byte(expectedUser))
+	passHash := sha256.Sum256([]byte(expectedPass))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			u, p, ok := r.BasicAuth()
+			if !ok {
+				log.Printf("AUTH FAILURE: basic_auth missing credentials, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+				unauthorized(w)
+				return
+			}
+
+			uHash := sha256.Sum256([]byte(u))
+			pHash := sha256.Sum256([]byte(p))
+			if subtle.ConstantTimeCompare(uHash[:], userHash[:]) == 1 &&
+				subtle.ConstantTimeCompare(pHash[:], passHash[:]) == 1 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			log.Printf("AUTH FAILURE: basic_auth invalid credentials, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+			unauthorized(w)
+		})
+	}
+}
+
+func unauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="GoTail UI", charset="UTF-8"`)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}
+```
+
+- [ ] **Step 2: Add logging to APIKeyAuth and EitherAuth**
+
+In `middleware/api_key_auth.go`, add `"log"` to imports. Update `APIKeyAuth` and `EitherAuth` failure paths:
+
+In `APIKeyAuth` handler (around lines 44-52):
+
+```go
+return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    key := extractAPIKey(r)
+    if key == "" {
+        log.Printf("AUTH FAILURE: api_key missing, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+        unauthorizedJSON(w, "API key required")
+        return
+    }
+
+    if !validateAPIKey(key) {
+        log.Printf("AUTH FAILURE: api_key invalid, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+        unauthorizedJSON(w, "Invalid API key")
+        return
+    }
+
+    next.ServeHTTP(w, r)
+})
+```
+
+In `EitherAuth`, at the final failure (line 88):
+
+```go
+// Neither authentication method succeeded
+log.Printf("AUTH FAILURE: either_auth no valid method, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+unauthorized(w)
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add middleware/basic_auth.go middleware/api_key_auth.go
+git commit -m "feat: log failed authentication attempts"
+```
+
+---
+
+## Chunk 4: Stats Date Filtering Fix
+
+### Task 6: Replace LIKE with date range queries in stats
+
+**Files:**
+- Modify: `db/sqlite/stats.go`
+
+- [ ] **Step 1: Rewrite all stats methods with proper date ranges**
+
+Replace `db/sqlite/stats.go` entirely:
+
+```go
+package sqlite
+
+import (
+	"time"
+)
+
+func dateRange(year int, month int) (string, string) {
+	loc, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		loc = time.FixedZone("CET", 1*60*60)
+	}
+	start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, loc)
+	end := start.AddDate(0, 1, 0)
+	return start.Format(time.RFC3339), end.Format(time.RFC3339)
+}
+
+func (s *SQLiteStore) CountLogsByMonth(year int, month int) (int, error) {
+	start, end := dateRange(year, month)
+	var count int
+	err := s.readDB.QueryRow(
+		"SELECT COUNT(*) FROM log WHERE timestamp >= ? AND timestamp < ?",
+		start, end,
+	).Scan(&count)
+	return count, err
+}
+
+func (s *SQLiteStore) CountLogsBySeverity(year int, month int) (map[string]int, error) {
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT severity_text, COUNT(*)
+		FROM log
+		WHERE timestamp >= ? AND timestamp < ?
+		GROUP BY severity_text`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]int)
+	for rows.Next() {
+		var severity string
+		var count int
+		if err := rows.Scan(&severity, &count); err != nil {
+			return nil, err
+		}
+		result[severity] = count
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) CountLogsPerDay(year int, month int) (map[int]int, error) {
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT CAST(strftime('%d', timestamp) AS INTEGER) AS day, COUNT(*)
+		FROM log
+		WHERE timestamp >= ? AND timestamp < ?
+		GROUP BY day
+		ORDER BY day`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[int]int)
+	for rows.Next() {
+		var day int
+		var count int
+		if err := rows.Scan(&day, &count); err != nil {
+			return nil, err
+		}
+		result[day] = count
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) CountLogsByService(year int, month int) (map[string]int, error) {
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT service_name, COUNT(*)
+		FROM log
+		WHERE timestamp >= ? AND timestamp < ? AND service_name IS NOT NULL
+		GROUP BY service_name`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]int)
+	for rows.Next() {
+		var service string
+		var count int
+		if err := rows.Scan(&service, &count); err != nil {
+			return nil, err
+		}
+		result[service] = count
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) CountLogsByAttribute(year int, month int) (map[string]int, error) {
+	start, end := dateRange(year, month)
+	rows, err := s.readDB.Query(`
+		SELECT key, COUNT(DISTINCT log_id)
+		FROM attribute
+		WHERE log_id IN (
+			SELECT id FROM log WHERE timestamp >= ? AND timestamp < ?
+		)
+		GROUP BY key`, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]int)
+	for rows.Next() {
+		var key string
+		var count int
+		if err := rows.Scan(&key, &count); err != nil {
+			return nil, err
+		}
+		result[key] = count
+	}
+	return result, rows.Err()
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/sqlite/stats.go
+git commit -m "fix: replace LIKE with date range queries in stats"
+```
+
+---
+
+## Chunk 5: Integration & Concurrency Tests
+
+### Task 7: Create test helpers
+
+**Files:**
+- Create: `db/sqlite/testhelper_test.go`
+
+- [ ] **Step 1: Create test helper with DB setup/teardown**
+
+This helper creates a temp SQLite DB, applies migrations from the SQL file, and returns a ready store.
+
+```go
+package sqlite_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotail/db/sqlite"
+)
+
+func newTestStore(t *testing.T) *sqlite.SQLiteStore {
+	t.Helper()
+	dir := t.TempDir()
+	dsn := filepath.Join(dir, "test.db")
+
+	store, err := sqlite.NewSQLiteStore(dsn)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	// Apply migration SQL directly
+	migrationSQL, err := os.ReadFile("../../migrations/20250625192434_log.sql")
+	if err != nil {
+		t.Fatalf("failed to read migration: %v", err)
+	}
+
+	// Extract only the Up migration (between +goose Up and +goose Down)
+	sql := extractUpMigration(string(migrationSQL))
+
+	if err := store.ExecRaw(sql); err != nil {
+		t.Fatalf("failed to apply migration: %v", err)
+	}
+
+	t.Cleanup(func() {
+		store.Close()
+	})
+
+	return store
+}
+
+func extractUpMigration(content string) string {
+	inUp := false
+	inStatement := false
+	var result string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "+goose Up") {
+			inUp = true
+			continue
+		}
+		if strings.Contains(line, "+goose Down") {
+			break
+		}
+		if inUp && strings.Contains(line, "+goose StatementBegin") {
+			inStatement = true
+			continue
+		}
+		if inUp && strings.Contains(line, "+goose StatementEnd") {
+			inStatement = false
+			continue
+		}
+		if inUp && inStatement {
+			result += line + "\n"
+		}
+	}
+	return result
+}
+```
+
+- [ ] **Step 2: Add ExecRaw method to SQLiteStore**
+
+In `db/sqlite/store.go`, add a method for running raw SQL (used by tests for migrations):
+
+```go
+func (s *SQLiteStore) ExecRaw(sql string) error {
+	_, err := s.writeDB.Exec(sql)
+	return err
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go build ./...`
+
+### Task 8: Write store-level tests
+
+**Files:**
+- Create: `db/sqlite/store_test.go`
+
+- [ ] **Step 1: Write basic CRUD and concurrency tests**
+
+```go
+package sqlite_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"gotail/models"
+)
+
+func makeLogEntry(id string, svc string) models.LogEntry {
+	s := svc
+	return models.LogEntry{
+		ID:           id,
+		Timestamp:    time.Now().UTC(),
+		SeverityText: "INFO",
+		SeverityNumber: 9,
+		Body:         "test log body",
+		ServiceName:  &s,
+		Attributes:   map[string]any{"env": "test"},
+	}
+}
+
+func TestInsertAndGetLogs(t *testing.T) {
+	store := newTestStore(t)
+
+	entry := makeLogEntry("test-1", "svc-a")
+	if err := store.InsertLog(entry); err != nil {
+		t.Fatalf("InsertLog failed: %v", err)
+	}
+
+	logs, count, err := store.GetLogsFiltered(1, 10, "", "", "", "")
+	if err != nil {
+		t.Fatalf("GetLogsFiltered failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected count 1, got %d", count)
+	}
+	if len(logs) != 1 {
+		t.Errorf("expected 1 log, got %d", len(logs))
+	}
+	if logs[0].ID != "test-1" {
+		t.Errorf("expected ID test-1, got %s", logs[0].ID)
+	}
+	// Check attributes were stored
+	if logs[0].Attributes["env"] != "test" {
+		t.Errorf("expected attribute env=test, got %v", logs[0].Attributes["env"])
+	}
+}
+
+func TestGetAttributeKeys(t *testing.T) {
+	store := newTestStore(t)
+
+	entry := makeLogEntry("test-1", "svc-a")
+	entry.Attributes = map[string]any{"env": "prod", "region": "eu"}
+	store.InsertLog(entry)
+
+	keys, err := store.GetAttributeKeys()
+	if err != nil {
+		t.Fatalf("GetAttributeKeys failed: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(keys))
+	}
+}
+
+func TestGetServices(t *testing.T) {
+	store := newTestStore(t)
+
+	store.InsertLog(makeLogEntry("test-1", "svc-a"))
+	store.InsertLog(makeLogEntry("test-2", "svc-b"))
+
+	services, err := store.GetServices()
+	if err != nil {
+		t.Fatalf("GetServices failed: %v", err)
+	}
+	if len(services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(services))
+	}
+}
+
+func TestCountLogsByMonth(t *testing.T) {
+	store := newTestStore(t)
+
+	now := time.Now().UTC()
+	entry := makeLogEntry("test-1", "svc-a")
+	entry.Timestamp = now
+	store.InsertLog(entry)
+
+	count, err := store.CountLogsByMonth(now.Year(), int(now.Month()))
+	if err != nil {
+		t.Fatalf("CountLogsByMonth failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+}
+
+func TestConcurrentWrites(t *testing.T) {
+	store := newTestStore(t)
+	var wg sync.WaitGroup
+	errs := make(chan error, 50)
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			entry := makeLogEntry(fmt.Sprintf("concurrent-%d", i), "svc-a")
+			if err := store.InsertLog(entry); err != nil {
+				errs <- fmt.Errorf("insert %d: %w", i, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+
+	total, err := store.GetTotalLogs()
+	if err != nil {
+		t.Fatalf("GetTotalLogs failed: %v", err)
+	}
+	if total != 50 {
+		t.Errorf("expected 50 logs, got %d", total)
+	}
+}
+
+func TestConcurrentReads(t *testing.T) {
+	store := newTestStore(t)
+
+	// Insert test data
+	for i := 0; i < 10; i++ {
+		store.InsertLog(makeLogEntry(fmt.Sprintf("read-%d", i), "svc-a"))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, count, err := store.GetLogsFiltered(1, 10, "", "", "", "")
+			if err != nil {
+				errs <- fmt.Errorf("GetLogsFiltered: %w", err)
+				return
+			}
+			if count != 10 {
+				errs <- fmt.Errorf("expected 10, got %d", count)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestConcurrentReadsAndWrites(t *testing.T) {
+	store := newTestStore(t)
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+
+	// 25 concurrent writers
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			entry := makeLogEntry(fmt.Sprintf("mixed-%d", i), "svc-a")
+			if err := store.InsertLog(entry); err != nil {
+				errs <- fmt.Errorf("insert %d: %w", i, err)
+			}
+		}(i)
+	}
+
+	// 25 concurrent readers
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := store.GetLogsFiltered(1, 10, "", "", "", "")
+			if err != nil {
+				errs <- fmt.Errorf("GetLogsFiltered: %w", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go test ./db/sqlite/ -v -race`
+Expected: all tests pass, no race conditions
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/sqlite/store.go db/sqlite/testhelper_test.go db/sqlite/store_test.go
+git commit -m "test: add store-level and concurrency tests"
+```
+
+### Task 9: Write integration tests for HTTP endpoints
+
+**Files:**
+- Create: `handlers/integration_test.go`
+
+- [ ] **Step 1: Write endpoint integration tests**
+
+```go
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotail/db/sqlite"
+	"gotail/handlers/api"
+	"gotail/handlers/logging"
+	"gotail/models"
+)
+
+func newTestStore(t *testing.T) *sqlite.SQLiteStore {
+	t.Helper()
+	dir := t.TempDir()
+	dsn := filepath.Join(dir, "test.db")
+
+	store, err := sqlite.NewSQLiteStore(dsn)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	migrationSQL, err := os.ReadFile("../migrations/20250625192434_log.sql")
+	if err != nil {
+		t.Fatalf("failed to read migration: %v", err)
+	}
+
+	sql := extractUpMigration(string(migrationSQL))
+	if err := store.ExecRaw(sql); err != nil {
+		t.Fatalf("failed to apply migration: %v", err)
+	}
+
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func extractUpMigration(content string) string {
+	inUp := false
+	inStatement := false
+	var result string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "+goose Up") {
+			inUp = true
+			continue
+		}
+		if strings.Contains(line, "+goose Down") {
+			break
+		}
+		if inUp && strings.Contains(line, "+goose StatementBegin") {
+			inStatement = true
+			continue
+		}
+		if inUp && strings.Contains(line, "+goose StatementEnd") {
+			inStatement = false
+			continue
+		}
+		if inUp && inStatement {
+			result += line + "\n"
+		}
+	}
+	return result
+}
+
+func postLog(handler http.Handler, entry models.LogEntry) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(entry)
+	req := httptest.NewRequest(http.MethodPost, "/log", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestPostLog_Valid(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	svc := "test-service"
+	entry := models.LogEntry{
+		Timestamp:      time.Now().UTC(),
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           "test message",
+		ServiceName:    &svc,
+		Attributes:     map[string]any{"env": "test"},
+	}
+
+	rr := postLog(http.HandlerFunc(handler.HandleLogInsert), entry)
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	total, _ := store.GetTotalLogs()
+	if total != 1 {
+		t.Errorf("expected 1 log, got %d", total)
+	}
+}
+
+func TestPostLog_InvalidJSON(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	req := httptest.NewRequest(http.MethodPost, "/log", strings.NewReader("not json"))
+	rr := httptest.NewRecorder()
+	handler.HandleLogInsert(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestPostLog_BodyTooLarge(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	entry := models.LogEntry{
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           strings.Repeat("x", 70000), // > 64KB
+	}
+
+	rr := postLog(http.HandlerFunc(handler.HandleLogInsert), entry)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPostLog_TooManyAttributes(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	attrs := make(map[string]any)
+	for i := 0; i < 51; i++ {
+		attrs[fmt.Sprintf("key-%d", i)] = "val"
+	}
+
+	entry := models.LogEntry{
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           "test",
+		Attributes:     attrs,
+	}
+
+	rr := postLog(http.HandlerFunc(handler.HandleLogInsert), entry)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetLogsAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	// Insert a log
+	svc := "svc-a"
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "ERROR", SeverityNumber: 17, Body: "err", ServiceName: &svc,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?severity=ERROR", nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleLogsAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp models.LogsAPIResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 1 {
+		t.Errorf("expected total 1, got %d", resp.Total)
+	}
+}
+
+func TestGetStatsAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	svc := "svc-a"
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "INFO", SeverityNumber: 9, Body: "msg", ServiceName: &svc,
+	})
+
+	now := time.Now()
+	url := fmt.Sprintf("/api/stats?year=%d&month=%d", now.Year(), int(now.Month()))
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleStatsAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetAttributeKeysAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "INFO", SeverityNumber: 9, Body: "msg",
+		Attributes: map[string]any{"env": "prod"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/attributes", nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleAttributeKeysAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestGetServicesAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	svc := "my-service"
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "INFO", SeverityNumber: 9, Body: "msg", ServiceName: &svc,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/services", nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleServicesAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestConcurrentHTTPReadsAndWrites(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+
+	// 25 concurrent POST /log
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			svc := "svc"
+			rr := postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+				SeverityText: "INFO", SeverityNumber: 9,
+				Body: fmt.Sprintf("msg-%d", i), ServiceName: &svc,
+			})
+			if rr.Code != http.StatusNoContent {
+				errs <- fmt.Errorf("POST /log %d: got %d", i, rr.Code)
+			}
+		}(i)
+	}
+
+	// 25 concurrent GET /api/logs
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+			rr := httptest.NewRecorder()
+			apiHandler.HandleLogsAPI(rr, req)
+			if rr.Code != http.StatusOK {
+				errs <- fmt.Errorf("GET /api/logs: got %d", rr.Code)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cd /Users/madsnylund/Documents/gotail && go test ./... -v -race`
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add handlers/integration_test.go
+git commit -m "test: add endpoint integration and concurrent HTTP tests"
+```

--- a/docs/superpowers/specs/2026-03-11-concurrency-fix-and-hardening-design.md
+++ b/docs/superpowers/specs/2026-03-11-concurrency-fix-and-hardening-design.md
@@ -1,0 +1,116 @@
+# Concurrency Fix & Security Hardening — Design Spec
+
+**Date:** 2026-03-11
+**Issue:** #9 — Conflict between parallel endpoint requests
+**Branch:** 9-conflict-between-parallell-endpoint-requests
+
+## Problem
+
+SQLite fails with `cannot start a transaction within a transaction` when concurrent read and write requests hit the database. The root cause is Go's `database/sql` connection pooling sharing a single connection between a write transaction (InsertLog) and concurrent read queries. After this error, no further insertions work.
+
+Additional vulnerabilities identified during investigation: missing input validation, no panic recovery, no auth failure logging, and incorrect date filtering in stats queries.
+
+## Changes
+
+### 1. WAL Mode + Dual Connection Pools
+
+**Files:** `db/sqlite/store.go`, `db/sqlite/get.go`, `db/sqlite/insert.go`, `db/sqlite/stats.go`, `main.go`
+
+The `SQLiteStore` gets two separate connection pools:
+
+```go
+type SQLiteStore struct {
+    writeDB *sql.DB    // MaxOpenConns(1), mutex-protected
+    readDB  *sql.DB    // read-only connection pool
+    mu      sync.Mutex // protects writeDB only
+}
+```
+
+**Initialization:**
+- Open write connection: DSN + `?_busy_timeout=5000`
+- Open read connection: DSN + `?mode=ro&_busy_timeout=5000`
+- Execute `PRAGMA journal_mode=WAL` on write connection
+- `writeDB.SetMaxOpenConns(1)`
+
+**Read methods** (`GetLogsFiltered`, `GetAttributeKeys`, `GetTotalLogs`, `GetServices`, all stats methods):
+- Switch from `s.db` to `s.readDB`
+- Wrap queries in a read-only transaction (`s.readDB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})`) for snapshot consistency
+- `GetLogsFiltered` benefits most: count query, data query, and per-log attribute queries all see the same snapshot
+
+**Write methods** (`InsertLog`):
+- Continue using `s.writeDB` with mutex protection
+- No change to transaction logic
+
+### 2. Input Validation
+
+**Files:** `middleware/max_body_size.go` (new), `handlers/logging/insert.go`
+
+**Request body size limit:**
+- New `MaxBodySize` middleware using `http.MaxBytesReader` with 1MB limit
+- Applied to POST /log route only
+
+**Field validation in insert handler (after JSON parsing):**
+- `Body`: max 64KB (65,536 bytes)
+- `SeverityText`, `ServiceName`, `HostName`, `ScopeName`: max 256 chars
+- `Attributes`: max 50 entries per log, key max 256 chars, value max 4KB (4,096 bytes)
+- Returns 400 with JSON error describing which field exceeded limits
+
+### 3. Panic Recovery Middleware
+
+**Files:** `middleware/recovery.go` (new), `main.go`
+
+- Wraps handler in deferred `recover()`
+- On panic: logs stack trace to stderr, returns HTTP 500 with JSON `{"error": "internal server error"}`
+- Applied as outermost middleware on all routes in `main.go`
+
+### 4. Failed Auth Attempt Logging
+
+**Files:** `middleware/basic_auth.go`, `middleware/api_key_auth.go`
+
+Log failed authentication attempts to stderr with:
+- Timestamp (via `log.Printf`)
+- Client IP (`r.RemoteAddr`)
+- Auth method (basic auth / API key)
+- Requested path
+
+No credentials are logged. Uses existing `log.Printf` pattern.
+
+### 5. Stats Date Filtering Fix
+
+**Files:** `db/sqlite/stats.go`
+
+Replace `LIKE` pattern matching with proper date range queries:
+
+- `CountLogsByMonth`: `WHERE timestamp >= ? AND timestamp < ?` using first/last day of month
+- `CountLogsPerDay`: Same range filter, group by `DATE(timestamp)` instead of `substr()`
+- `CountLogsByService` and `CountLogsBySeverity`: Same range-based filtering
+
+Enables proper use of `idx_log_ts` index.
+
+### 6. Endpoint & Concurrency Tests
+
+**Files:** New test files
+
+**Test database setup:**
+- Each test creates a temporary SQLite DB via `t.TempDir()`
+- Goose migrations applied programmatically
+- DB cleaned up automatically after test
+
+**Endpoint tests:**
+- POST /log — valid input, invalid input, oversized body, field validation
+- GET /api/logs — with filters, pagination
+- GET /api/stats — with year/month params
+- GET /api/attributes — returns attribute keys
+- GET /api/services — returns service list
+
+**Concurrency tests using `sync.WaitGroup`:**
+- Concurrent writes (multiple POST /log)
+- Concurrent reads (multiple GET /api/logs)
+- Mixed concurrent reads and writes
+- Assert: no errors, data consistency, no deadlocks
+
+## Out of Scope
+
+- Host header injection in docs.go (deferred)
+- Rate limiting
+- Open CORS on documentation endpoints

--- a/docs/superpowers/specs/2026-03-11-concurrency-fix-and-hardening-design.md
+++ b/docs/superpowers/specs/2026-03-11-concurrency-fix-and-hardening-design.md
@@ -28,14 +28,19 @@ type SQLiteStore struct {
 
 **Initialization:**
 - Open write connection: DSN + `?_busy_timeout=5000`
-- Open read connection: DSN + `?mode=ro&_busy_timeout=5000`
+- Open read connection: DSN + `?_busy_timeout=5000` and execute `PRAGMA query_only=ON` (since `mode=ro` may not be supported by `modernc.org/sqlite`)
 - Execute `PRAGMA journal_mode=WAL` on write connection
+- Execute `PRAGMA synchronous=NORMAL` (safe with WAL, better write performance)
+- Execute `PRAGMA foreign_keys=ON` (SQLite does not enforce by default)
 - `writeDB.SetMaxOpenConns(1)`
+- Remove broken busy_timeout logic from `main.go` (line 44 checks `dsn == "sqlite"` instead of `driver == "sqlite"` — the timeout is handled inside `NewSQLiteStore` now)
 
-**Read methods** (`GetLogsFiltered`, `GetAttributeKeys`, `GetTotalLogs`, `GetServices`, all stats methods):
+**`Close()` method** must close both `writeDB` and `readDB`.
+
+**Read methods** (`GetLogsFiltered`, `GetAttributeKeys`, `GetTotalLogs`, `GetServices`, all stats methods including `CountLogsByAttribute`):
 - Switch from `s.db` to `s.readDB`
-- Wrap queries in a read-only transaction (`s.readDB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})`) for snapshot consistency
-- `GetLogsFiltered` benefits most: count query, data query, and per-log attribute queries all see the same snapshot
+- Multi-query reads (`GetLogsFiltered`) wrapped in a read-only transaction for snapshot consistency
+- Single-query reads (`GetTotalLogs`, `GetAttributeKeys`, `GetServices`, individual stats methods) do not need transaction wrapping — a single query is already atomic
 
 **Write methods** (`InsertLog`):
 - Continue using `s.writeDB` with mutex protection
@@ -70,8 +75,10 @@ type SQLiteStore struct {
 Log failed authentication attempts to stderr with:
 - Timestamp (via `log.Printf`)
 - Client IP (`r.RemoteAddr`)
-- Auth method (basic auth / API key)
+- Auth method (basic auth / API key / either auth)
 - Requested path
+
+Also update the `EitherAuth` middleware's own failure path in `api_key_auth.go`.
 
 No credentials are logged. Uses existing `log.Printf` pattern.
 
@@ -84,12 +91,22 @@ Replace `LIKE` pattern matching with proper date range queries:
 - `CountLogsByMonth`: `WHERE timestamp >= ? AND timestamp < ?` using first/last day of month
 - `CountLogsPerDay`: Same range filter, group by `DATE(timestamp)` instead of `substr()`
 - `CountLogsByService` and `CountLogsBySeverity`: Same range-based filtering
+- `CountLogsByAttribute`: Same range-based filtering (also uses `LIKE` today)
+
+Date range boundaries computed in Go:
+```go
+start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, loc)
+end := start.AddDate(0, 1, 0)
+// WHERE timestamp >= start AND timestamp < end
+```
+
+Timestamps are stored as RFC 3339 strings which support lexicographic comparison.
 
 Enables proper use of `idx_log_ts` index.
 
 ### 6. Endpoint & Concurrency Tests
 
-**Files:** New test files
+**Files:** `db/sqlite/store_test.go` (new), `handlers/integration_test.go` (new)
 
 **Test database setup:**
 - Each test creates a temporary SQLite DB via `t.TempDir()`
@@ -109,8 +126,12 @@ Enables proper use of `idx_log_ts` index.
 - Mixed concurrent reads and writes
 - Assert: no errors, data consistency, no deadlocks
 
+**Auth in tests:** Tests inject handlers directly (bypassing auth middleware) for endpoint tests. Concurrency tests may use a test helper that sets up valid API keys.
+
 ## Out of Scope
 
 - Host header injection in docs.go (deferred)
 - Rate limiting
 - Open CORS on documentation endpoints
+- N+1 attribute query optimization in `GetLogsFiltered` (future)
+- Graceful HTTP server shutdown

--- a/handlers/integration_test.go
+++ b/handlers/integration_test.go
@@ -1,0 +1,287 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotail/db/sqlite"
+	"gotail/handlers/api"
+	"gotail/handlers/logging"
+	"gotail/models"
+)
+
+func newTestStore(t *testing.T) *sqlite.SQLiteStore {
+	t.Helper()
+	dir := t.TempDir()
+	dsn := filepath.Join(dir, "test.db")
+
+	store, err := sqlite.NewSQLiteStore(dsn)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	migrationSQL, err := os.ReadFile("../migrations/20250625192434_log.sql")
+	if err != nil {
+		t.Fatalf("failed to read migration: %v", err)
+	}
+
+	sql := extractUpMigration(string(migrationSQL))
+	if err := store.ExecRaw(sql); err != nil {
+		t.Fatalf("failed to apply migration: %v", err)
+	}
+
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func extractUpMigration(content string) string {
+	inUp := false
+	inStatement := false
+	var result string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "+goose Up") {
+			inUp = true
+			continue
+		}
+		if strings.Contains(line, "+goose Down") {
+			break
+		}
+		if inUp && strings.Contains(line, "+goose StatementBegin") {
+			inStatement = true
+			continue
+		}
+		if inUp && strings.Contains(line, "+goose StatementEnd") {
+			inStatement = false
+			continue
+		}
+		if inUp && inStatement {
+			result += line + "\n"
+		}
+	}
+	return result
+}
+
+func postLog(handler http.Handler, entry models.LogEntry) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(entry)
+	req := httptest.NewRequest(http.MethodPost, "/log", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestPostLog_Valid(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	svc := "test-service"
+	entry := models.LogEntry{
+		Timestamp:      time.Now().UTC(),
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           "test message",
+		ServiceName:    &svc,
+		Attributes:     map[string]any{"env": "test"},
+	}
+
+	rr := postLog(http.HandlerFunc(handler.HandleLogInsert), entry)
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	total, _ := store.GetTotalLogs()
+	if total != 1 {
+		t.Errorf("expected 1 log, got %d", total)
+	}
+}
+
+func TestPostLog_InvalidJSON(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	req := httptest.NewRequest(http.MethodPost, "/log", strings.NewReader("not json"))
+	rr := httptest.NewRecorder()
+	handler.HandleLogInsert(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestPostLog_BodyTooLarge(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	entry := models.LogEntry{
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           strings.Repeat("x", 70000), // > 64KB
+	}
+
+	rr := postLog(http.HandlerFunc(handler.HandleLogInsert), entry)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPostLog_TooManyAttributes(t *testing.T) {
+	store := newTestStore(t)
+	handler := &logging.LogHandler{Store: store}
+
+	attrs := make(map[string]any)
+	for i := 0; i < 51; i++ {
+		attrs[fmt.Sprintf("key-%d", i)] = "val"
+	}
+
+	entry := models.LogEntry{
+		SeverityText:   "INFO",
+		SeverityNumber: 9,
+		Body:           "test",
+		Attributes:     attrs,
+	}
+
+	rr := postLog(http.HandlerFunc(handler.HandleLogInsert), entry)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetLogsAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	// Insert a log
+	svc := "svc-a"
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "ERROR", SeverityNumber: 17, Body: "err", ServiceName: &svc,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?severity=ERROR", nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleLogsAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp models.LogsAPIResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 1 {
+		t.Errorf("expected total 1, got %d", resp.Total)
+	}
+}
+
+func TestGetStatsAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	svc := "svc-a"
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "INFO", SeverityNumber: 9, Body: "msg", ServiceName: &svc,
+	})
+
+	now := time.Now()
+	url := fmt.Sprintf("/api/stats?year=%d&month=%d", now.Year(), int(now.Month()))
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleStatsAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetAttributeKeysAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "INFO", SeverityNumber: 9, Body: "msg",
+		Attributes: map[string]any{"env": "prod"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/attributes", nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleAttributeKeysAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestGetServicesAPI(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	svc := "my-service"
+	postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+		SeverityText: "INFO", SeverityNumber: 9, Body: "msg", ServiceName: &svc,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/services", nil)
+	rr := httptest.NewRecorder()
+	apiHandler.HandleServicesAPI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestConcurrentHTTPReadsAndWrites(t *testing.T) {
+	store := newTestStore(t)
+	logHandler := &logging.LogHandler{Store: store}
+	apiHandler := &api.APIHandler{Store: store}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+
+	// 25 concurrent POST /log
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			svc := "svc"
+			rr := postLog(http.HandlerFunc(logHandler.HandleLogInsert), models.LogEntry{
+				SeverityText: "INFO", SeverityNumber: 9,
+				Body: fmt.Sprintf("msg-%d", i), ServiceName: &svc,
+			})
+			if rr.Code != http.StatusNoContent {
+				errs <- fmt.Errorf("POST /log %d: got %d", i, rr.Code)
+			}
+		}(i)
+	}
+
+	// 25 concurrent GET /api/logs
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+			rr := httptest.NewRecorder()
+			apiHandler.HandleLogsAPI(rr, req)
+			if rr.Code != http.StatusOK {
+				errs <- fmt.Errorf("GET /api/logs: got %d", rr.Code)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}

--- a/handlers/logging/insert.go
+++ b/handlers/logging/insert.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -11,6 +12,14 @@ import (
 
 	"gotail/db"
 	"gotail/models"
+)
+
+const (
+	maxBodyLen      = 65536 // 64KB
+	maxStringLen    = 256
+	maxAttributes   = 50
+	maxAttrKeyLen   = 256
+	maxAttrValueLen = 4096 // 4KB
 )
 
 type LogHandler struct {
@@ -24,12 +33,17 @@ func (h *LogHandler) HandleLogInsert(w http.ResponseWriter, r *http.Request) {
 	}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "Invalid body", http.StatusBadRequest)
+		writeJSONError(w, "Request body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 	var logEntry models.LogEntry
 	if err := json.Unmarshal(body, &logEntry); err != nil {
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		writeJSONError(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if msg := validateLogEntry(logEntry); msg != "" {
+		writeJSONError(w, msg, http.StatusBadRequest)
 		return
 	}
 
@@ -42,8 +56,44 @@ func (h *LogHandler) HandleLogInsert(w http.ResponseWriter, r *http.Request) {
 	err = h.Store.InsertLog(logEntry)
 	if err != nil {
 		log.Printf("Failed to insert log: %v", err)
-		http.Error(w, "Failed to insert log", http.StatusInternalServerError)
+		writeJSONError(w, "Failed to insert log", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func validateLogEntry(e models.LogEntry) string {
+	if len(e.Body) > maxBodyLen {
+		return fmt.Sprintf("body exceeds maximum length of %d bytes", maxBodyLen)
+	}
+	if len(e.SeverityText) > maxStringLen {
+		return fmt.Sprintf("severity_text exceeds maximum length of %d chars", maxStringLen)
+	}
+	if e.ServiceName != nil && len(*e.ServiceName) > maxStringLen {
+		return fmt.Sprintf("service_name exceeds maximum length of %d chars", maxStringLen)
+	}
+	if e.HostName != nil && len(*e.HostName) > maxStringLen {
+		return fmt.Sprintf("host_name exceeds maximum length of %d chars", maxStringLen)
+	}
+	if e.ScopeName != nil && len(*e.ScopeName) > maxStringLen {
+		return fmt.Sprintf("scope_name exceeds maximum length of %d chars", maxStringLen)
+	}
+	if len(e.Attributes) > maxAttributes {
+		return fmt.Sprintf("attributes exceeds maximum count of %d", maxAttributes)
+	}
+	for k, v := range e.Attributes {
+		if len(k) > maxAttrKeyLen {
+			return fmt.Sprintf("attribute key %q exceeds maximum length of %d chars", k, maxAttrKeyLen)
+		}
+		if str, ok := v.(string); ok && len(str) > maxAttrValueLen {
+			return fmt.Sprintf("attribute value for key %q exceeds maximum length of %d bytes", k, maxAttrValueLen)
+		}
+	}
+	return ""
+}
+
+func writeJSONError(w http.ResponseWriter, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": message})
 }

--- a/main.go
+++ b/main.go
@@ -70,11 +70,13 @@ func main() {
 	})
 
 	// Route for submitting logs (POST) - accepts both API key and basic auth
+	logHandlerWithLimit := middleware.MaxBodySize(1 << 20)(http.HandlerFunc(logHandler.HandleLogInsert))
+
 	if user != "" && pass != "" {
-		http.Handle("/log", middleware.EitherAuth(user, pass)(http.HandlerFunc(logHandler.HandleLogInsert)))
+		http.Handle("/log", middleware.EitherAuth(user, pass)(logHandlerWithLimit))
 	} else if apiKeys != "" {
 		// Headless mode with only API key auth for /log
-		http.Handle("/log", middleware.APIKeyAuth()(http.HandlerFunc(logHandler.HandleLogInsert)))
+		http.Handle("/log", middleware.APIKeyAuth()(logHandlerWithLimit))
 	}
 
 	// API routes (available if API keys are configured)

--- a/main.go
+++ b/main.go
@@ -97,5 +97,5 @@ func main() {
 	if headlessMode {
 		log.Println("Running in headless mode (UI disabled)")
 	}
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Fatal(http.ListenAndServe(":8080", middleware.Recovery(http.DefaultServeMux)))
 }

--- a/main.go
+++ b/main.go
@@ -39,12 +39,6 @@ func main() {
 		log.Fatal("DB_DRIVER and DB_DSN must be set in .env")
 	}
 
-	// Set busy timeout for SQLite if using SQLite
-	// This is important to avoid database lock issues
-	if dsn == "sqlite" {
-		dsn = dsn + "?_busy_timeout=5000"
-	}
-
 	// Initialize the correct DB store based on driver
 	store, err := db.New(driver, dsn)
 	if err != nil {

--- a/middleware/api_key_auth.go
+++ b/middleware/api_key_auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"crypto/sha256"
 	"crypto/subtle"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -43,11 +44,13 @@ func APIKeyAuth() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			key := extractAPIKey(r)
 			if key == "" {
+				log.Printf("AUTH FAILURE: api_key missing, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
 				unauthorizedJSON(w, "API key required")
 				return
 			}
 
 			if !validateAPIKey(key) {
+				log.Printf("AUTH FAILURE: api_key invalid, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
 				unauthorizedJSON(w, "Invalid API key")
 				return
 			}
@@ -85,6 +88,7 @@ func EitherAuth(expectedUser, expectedPass string) func(http.Handler) http.Handl
 			}
 
 			// Neither authentication method succeeded
+			log.Printf("AUTH FAILURE: either_auth no valid method, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
 			unauthorized(w)
 		})
 	}

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -1,36 +1,39 @@
 package middleware
 
 import (
-  "crypto/sha256"
-  "crypto/subtle"
-  "net/http"
+	"crypto/sha256"
+	"crypto/subtle"
+	"log"
+	"net/http"
 )
 
 func BasicAuth(expectedUser, expectedPass string) func(http.Handler) http.Handler {
-  userHash := sha256.Sum256([]byte(expectedUser))
-  passHash := sha256.Sum256([]byte(expectedPass))
-  return func(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-      u, p, ok := r.BasicAuth()
-      if !ok {
-        unauthorized(w)
-        return
-      }
+	userHash := sha256.Sum256([]byte(expectedUser))
+	passHash := sha256.Sum256([]byte(expectedPass))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			u, p, ok := r.BasicAuth()
+			if !ok {
+				log.Printf("AUTH FAILURE: basic_auth missing credentials, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+				unauthorized(w)
+				return
+			}
 
-      uHash := sha256.Sum256([]byte(u))
-      pHash := sha256.Sum256([]byte(p))
-      if subtle.ConstantTimeCompare(uHash[:], userHash[:]) == 1 &&
-         subtle.ConstantTimeCompare(pHash[:], passHash[:]) == 1 {
-        next.ServeHTTP(w, r)
-        return
-      }
+			uHash := sha256.Sum256([]byte(u))
+			pHash := sha256.Sum256([]byte(p))
+			if subtle.ConstantTimeCompare(uHash[:], userHash[:]) == 1 &&
+				subtle.ConstantTimeCompare(pHash[:], passHash[:]) == 1 {
+				next.ServeHTTP(w, r)
+				return
+			}
 
-      unauthorized(w)
-    })
-  }
+			log.Printf("AUTH FAILURE: basic_auth invalid credentials, ip=%s path=%s", r.RemoteAddr, r.URL.Path)
+			unauthorized(w)
+		})
+	}
 }
 
 func unauthorized(w http.ResponseWriter) {
-  w.Header().Set("WWW-Authenticate", `Basic realm="GoTail UI", charset="UTF-8"`)
-  http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	w.Header().Set("WWW-Authenticate", `Basic realm="GoTail UI", charset="UTF-8"`)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
 }

--- a/middleware/max_body_size.go
+++ b/middleware/max_body_size.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/middleware/recovery.go
+++ b/middleware/recovery.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"runtime/debug"
+)
+
+func Recovery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("PANIC: %v\n%s", err, debug.Stack())
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error":"internal server error"}`))
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## Summary

- **Fix SQLite concurrent request conflicts** (closes #9): Dual connection pools (read/write separation) with WAL mode. Write pool is mutex-protected with `MaxOpenConns(1)`, read pool allows concurrent readers with `query_only=ON`.
- **Input validation on POST /log**: 1MB body size limit middleware, field length validation (body 64KB, strings 256 chars, max 50 attributes)
- **Panic recovery middleware**: Catches panics, logs stack traces, returns 500 JSON
- **Failed auth attempt logging**: Logs IP and path on failed basic auth, API key, and EitherAuth attempts
- **Stats date filtering fix**: Replaced `LIKE` pattern matching with proper date range queries (`>=` / `<`)
- **Comprehensive test suite**: Store-level CRUD tests, concurrency tests (50 concurrent writes, 20 concurrent reads, mixed read/write), HTTP integration tests, and concurrent HTTP endpoint tests — all with `-race` detector

## Test plan

- [x] `go test ./... -race` — 33 tests pass, zero race conditions
- [x] Concurrent writes (50 goroutines) complete without transaction conflicts
- [x] Mixed concurrent reads + writes (25 each) complete without errors
- [x] Input validation rejects oversized body, too many attributes
- [x] Stats API returns correct results with date range queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)